### PR TITLE
fix: make check-dev-files suitable for pre-commit

### DIFF
--- a/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
@@ -10,6 +10,7 @@ from .editor_config_hook import check_editor_config_hook
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Dummy for pre-commit")
     parser.add_argument(
         "--no-fix",
         default=False,

--- a/src/repoma/pre_commit_hooks/check_dev_files/editor_config_hook.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/editor_config_hook.py
@@ -34,20 +34,20 @@ def check_editor_config_hook() -> None:
 
 
 def _has_editor_config() -> bool:
-    if not os.path.exists(".editorconfig"):
+    if not os.path.exists(__EDITORCONFIG_FILE):
         return False
     return True
 
 
 def _has_precommit_hook() -> bool:
-    if not os.path.exists(".editorconfig"):
+    if not os.path.exists(__PRECOMMIT_CONFIG_FILE):
         return False
-    with open(".pre-commit-config.yaml") as stream:
+    with open(__PRECOMMIT_CONFIG_FILE) as stream:
         config = yaml.load(stream, Loader=yaml.SafeLoader)
     repos = config.get("repos")
     if repos is None:
         return False
     repos_urls = {repo.get("repo") for repo in repos if isinstance(repo, dict)}
-    if __EDITORCONFIG_HOOK not in repos_urls:
+    if __EDITORCONFIG_URL not in repos_urls:
         return False
     return True


### PR DESCRIPTION
Two fixes:
- The `check-dev-files` hook failed, because it did not take file names as argument.
- Its check on the pre-commit hook for Editor Config (see #7) was faulty