### PR TITLE
feat: check missing entries cspell config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
           (?x)^(
             .*\.bib|
             .*\.svg|
-            .cspell.json
+            .*\.cspell\.json
           )$
       - id: mixed-line-ending
       - id: name-tests-test

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ where = src
 
 [options.package_data]
 repoma =
+    .cspell.json
     py.typed
 
 [mypy]

--- a/src/repoma/.cspell.json
+++ b/src/repoma/.cspell.json
@@ -1,0 +1,49 @@
+{
+    "version": "0.1",
+    "enableFiletypes": [
+        "git-commit",
+        "jupyter"
+    ],
+    "flagWords": [
+        "analyse",
+        "colour",
+        "comparision",
+        "favour",
+        "flavour",
+        "hte",
+        "optimise",
+        "paramater",
+        "parmater"
+    ],
+    "ignorePaths": [
+        "**/.cspell.json",
+        "*.bib",
+        "*.ico",
+        "*.root",
+        "*.rst_t",
+        "*.svg",
+        "*particle*.*ml",
+        ".gitignore",
+        ".gitpod.*",
+        ".pre-commit-config.yaml",
+        ".pylintrc",
+        ".readthedocs.yml",
+        ".vscode/*",
+        ".vscode/.gitignore",
+        "Makefile",
+        "codecov.yml",
+        "docs/_templates/*",
+        "docs/adr/*/*",
+        "docs/conf.py",
+        "pyproject.toml",
+        "pyrightconfig.json",
+        "reqs/**/*.in",
+        "reqs/**/*.txt",
+        "requirements*.txt",
+        "setup.cfg",
+        "setup.py",
+        "tox.ini",
+        "typings"
+    ],
+    "language": "en-US"
+}

--- a/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
@@ -19,12 +19,18 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="Fix the identified problems.",
     )
+    parser.add_argument(
+        "--extend",
+        default=False,
+        action="store_true",
+        help="Insert expected config entries rather than overwriting existing ones.",
+    )
     args = parser.parse_args(argv)
     fix = not args.no_fix
     try:
         check_editor_config_hook()
         check_has_labels(fix)
-        check_cspell_config(fix)
+        check_cspell_config(fix, args.extend)
         return 0
     except PrecommitError as exception:
         print(str("\n".join(exception.args)))

--- a/src/repoma/pre_commit_hooks/check_dev_files/cspell_config.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/cspell_config.py
@@ -6,10 +6,15 @@ See `cSpell
 
 import json
 import os
+from typing import Any
 
+import repoma
 from repoma.pre_commit_hooks.errors import PrecommitError
 
 __EXPECTED_CONFIG_FILE = ".cspell.json"
+__REPOMA_DIR = os.path.dirname(repoma.__file__)
+with open(f"{__REPOMA_DIR}/{__EXPECTED_CONFIG_FILE}") as __STREAM:
+    __EXPECTED_CONFIG = json.load(__STREAM)
 
 __JSON_DUMP_OPTIONS = {
     "indent": 4,
@@ -17,9 +22,10 @@ __JSON_DUMP_OPTIONS = {
 }
 
 
-def check_cspell_config(fix: bool) -> None:
+def check_cspell_config(fix: bool, extend: bool) -> None:
     _check_has_config()
     _fix_config_name(fix)
+    _fix_config_content(fix, extend)
     _sort_config_entries(fix)
 
 
@@ -41,6 +47,57 @@ def _fix_config_name(fix: bool) -> None:
         )
 
 
+def _fix_config_content(fix: bool, extend: bool) -> None:
+    with open(__EXPECTED_CONFIG_FILE) as stream:
+        config = json.load(stream)
+    error_message = ""
+    for section in __EXPECTED_CONFIG:
+        expected_section_content = __get_expected_content(
+            config, section, extend=extend
+        )
+        section_content = config.get(section)
+        if section_content == expected_section_content:
+            continue
+        error_message += (
+            f'Section "{section}" in cSpell config '
+            f'"./{__EXPECTED_CONFIG_FILE}" is missing expected entries.'
+        )
+        config[section] = expected_section_content
+        if fix:
+            error_message += " Problem has been fixed."
+        else:
+            error_message += " Content should be:\n\n"
+            error_message += __render_section(config, section)
+            error_message += "\n"
+        break
+    if fix:
+        with open(__EXPECTED_CONFIG_FILE, "w") as stream:
+            json.dump(config, stream, **__JSON_DUMP_OPTIONS)  # type: ignore
+    if error_message:
+        raise PrecommitError(error_message)
+
+
+def __get_expected_content(config: dict, section: str, *, extend: bool) -> Any:
+    if section not in config:
+        return __EXPECTED_CONFIG[section]
+    section_content = config[section]
+    if section not in __EXPECTED_CONFIG:
+        return section_content
+    expected_section_content = __EXPECTED_CONFIG[section]
+    if isinstance(expected_section_content, str):
+        return expected_section_content
+    if isinstance(expected_section_content, list):
+        if not extend:
+            return sorted(expected_section_content)
+        expected_section_content_set = set(expected_section_content)
+        expected_section_content_set.update(section_content)
+        return sorted(expected_section_content_set)
+    raise NotImplementedError(
+        "No implementation for section content of type"
+        f' {section_content.__class__.__name__} (section: "{section}"'
+    )
+
+
 def _sort_config_entries(fix: bool) -> None:
     with open(__EXPECTED_CONFIG_FILE) as stream:
         config = json.load(stream)
@@ -49,7 +106,7 @@ def _sort_config_entries(fix: bool) -> None:
         if not isinstance(section_content, list):
             continue
         sorted_section_content = sorted(section_content)
-        if sorted_section_content == section_content:
+        if section_content == sorted_section_content:
             continue
         error_message += (
             f'Section "{section}" in cSpell config '


### PR DESCRIPTION
Check whether the `.cspell.json` config contains all expected entries as defined in the [`src/repoma/.cspell.json`](https://github.com/ComPWA/repo-maintenance/blob/8bc89fb568385cead1367b8679c5c977576c68dc/src/repoma/.cspell.json) file.