### PR TITLE
feat: use new GitHub Actions in upgrade jobs

### DIFF
--- a/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/__init__.py
@@ -14,11 +14,11 @@ from .github_templates import check_github_templates
 from .github_workflows import check_docs_workflow, check_milestone_workflow
 from .gitpod import check_gitpod_config
 from .nbstripout import check_nbstripout
-from .pin_requirements_scripts import check_constraints_folder
 from .prettier_config import fix_prettier_config
 from .pyupgrade import update_pyupgrade_hook
 from .setup_cfg import fix_setup_cfg
 from .tox_config import check_tox_ini
+from .update_requirements_workflows import update_workflows
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -75,7 +75,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     executor(update_pyupgrade_hook)
     if is_python_repo:
         if args.pin_requirements:
-            executor(check_constraints_folder)
+            executor(update_workflows)
         executor(fix_setup_cfg, args.ignore_author)
         executor(check_tox_ini)
     if executor.error_messages:

--- a/src/repoma/pre_commit_hooks/check_dev_files/update_requirements_workflows.py
+++ b/src/repoma/pre_commit_hooks/check_dev_files/update_requirements_workflows.py
@@ -1,4 +1,9 @@
-"""Check if there is a ``pin_requirements.py`` script."""
+"""Update workflows that update pip constraints files.
+
+See Also:
+- https://github.com/ComPWA/update-pip-constraints
+- https://github.com/ComPWA/update-pre-commit
+"""
 
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
@@ -6,45 +11,25 @@ from repoma._utilities import (
     CONFIG_PATH,
     get_prettier_round_trip_yaml,
     get_supported_python_versions,
-    write_script,
 )
 from repoma.pre_commit_hooks.errors import PrecommitError
 
 
-def check_constraints_folder() -> None:
-    update_pin_requirements_script()
-    remove_bash_script()
-    update_github_workflows()
+def update_workflows() -> None:
+    _remove_script("pin_requirements.py")
+    _remove_script("upgrade.sh")
+    _update_github_workflows()
 
 
-def update_pin_requirements_script() -> None:
-    script_name = "pin_requirements.py"
-    expected_script_path = CONFIG_PATH.repoma_src / "devtools" / script_name
-    with open(expected_script_path) as stream:
-        expected_script = stream.read()
-    script_path = CONFIG_PATH.pip_constraints / script_name
-    if not script_path.exists():
-        write_script(content=expected_script, path=script_path)
-        raise PrecommitError(
-            f'This repository does not contain a "{script_name}" script.'
-            " Problem has been fixed"
-        )
-    with open(script_path) as stream:
-        existing_script = stream.read()
-    if existing_script != expected_script:
-        write_script(content=expected_script, path=script_path)
-        raise PrecommitError(f'Updated "{script_name}" script')
-
-
-def remove_bash_script() -> None:
-    bash_script_name = CONFIG_PATH.pip_constraints / "upgrade.sh"
+def _remove_script(script_name: str) -> None:
+    bash_script_name = CONFIG_PATH.pip_constraints / script_name
     if bash_script_name.exists():
         bash_script_name.unlink()
         raise PrecommitError(f'Removed deprecated "{bash_script_name}" script')
 
 
-def update_github_workflows() -> None:
-    def upgrade_workflow(workflow_file: str) -> None:
+def _update_github_workflows() -> None:
+    def overwrite_workflow(workflow_file: str) -> None:
         expected_workflow_path = (
             CONFIG_PATH.repoma_src / "workflows" / workflow_file
         )
@@ -68,5 +53,5 @@ def update_github_workflows() -> None:
             yaml.dump(expected_data, workflow_path)
             raise PrecommitError(f'Updated "{workflow_path}" workflow')
 
-    upgrade_workflow("requirements-cron.yml")
-    upgrade_workflow("requirements-pr.yml")
+    overwrite_workflow("requirements-cron.yml")
+    overwrite_workflow("requirements-pr.yml")

--- a/src/repoma/workflows/requirements-cron.yml
+++ b/src/repoma/workflows/requirements-cron.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  upgrade-requirements:
-    name: Upgrade pinned requirements
+  pip-constraints:
+    name: Update pip constraints files
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -15,64 +15,41 @@ jobs:
         python-version: []
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@master
+      - uses: ComPWA/update-pip-constraints@main
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pip-tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install pip-tools
-      - name: Upgrade pinned requirements
-        run: python3 .constraints/pin_requirements.py
-      - uses: actions/upload-artifact@v2
-        with:
-          path: .constraints/py${{ matrix.python-version }}.txt
 
-  upgrade-pre-commit:
-    name: Upgrade pre-commit hooks
+  pre-commit:
+    name: pre-commit autoupdate
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade pre-commit
-      - name: Autoupdate pre-commit
-        run: pre-commit autoupdate
-      - uses: actions/upload-artifact@v2
-        with:
-          path: .pre-commit-config.yaml
+      - uses: ComPWA/update-pre-commit@main
 
   push:
     name: Create PR
     runs-on: ubuntu-20.04
     needs:
-      - upgrade-pre-commit
-      - upgrade-requirements
+      - pip-constraints
+      - pre-commit
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PAT }}
+        # GITHUB_TOKEN will not rerun checks after pushing to a PR branch
       - uses: actions/download-artifact@v2
-        with:
-          path: .constraints
       - run: |
-          mv -f artifact/.pre-commit-config.yaml ..
-          mv -f artifact/* .
-        working-directory: .constraints
+          [[ -f .pre-commit-config.yaml ]] && mv -f .pre-commit-config.yaml ..
+          mv -f * ../.constraints/
+        working-directory: artifact
       - run: git status -s
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: "ci: upgrade pinned requirements"
+          commit-message: "ci: update pip constraints and pre-commit"
           committer: GitHub <noreply@github.com>
           author: GitHub <noreply@github.com>
-          title: "ci: upgrade pinned requirements"
+          title: "ci: update pip constraints and pre-commit"
           labels: |
             🖱️ DX
           branch-suffix: timestamp

--- a/src/repoma/workflows/requirements-pr.yml
+++ b/src/repoma/workflows/requirements-pr.yml
@@ -7,8 +7,8 @@ on:
       - epic/*
 
 jobs:
-  upgrade:
-    name: Upgrade pinned requirements
+  pip-constraints:
+    name: Update pip constraints files
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -16,57 +16,54 @@ jobs:
         python-version: []
     steps:
       - uses: actions/checkout@v2
-      - run: git fetch origin
-      - name: Check for modified dependencies
-        id: git-diff
-        run:
-          echo "::set-output name=dependency-changes::$(git diff
-          origin/$GITHUB_BASE_REF --name-only -- .constraints/ setup.cfg)"
-      - name: Show dependency changes changes
-        run: git diff origin/$GITHUB_BASE_REF -- .constraints/ setup.cfg
-      - name: Abort if fork PR and dependency changes
-        if:
-          github.event.pull_request.head.repo.full_name != github.repository &&
-          steps.git-diff.outputs.dependency-changes != ''
-        run: |
-          echo "::error::Cannot modify package dependencies through a PR from a fork"
-          exit 1
-      - name: Set up Python ${{ matrix.python-version }}
-        if: steps.git-diff.outputs.dependency-changes != ''
-        uses: actions/setup-python@master
+        with:
+          fetch-depth: 0
+      - name: Check if there are dependency changes
+        run: git diff origin/main --exit-code -- .constraints setup.cfg
+        continue-on-error: true
+      - uses: ComPWA/update-pip-constraints@main
+        if: success()
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        if: steps.git-diff.outputs.dependency-changes != ''
-        run: |
-          python -m pip install --upgrade pip
-          pip install pip-tools
-      - name: Upgrade dependencies
-        if: steps.git-diff.outputs.dependency-changes != ''
-        run: python3 .constraints/pin_requirements.py
-      - uses: actions/upload-artifact@v2
+
+  pre-commit:
+    name: pre-commit autoupdate
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
         with:
-          path: .constraints/py${{ matrix.python-version }}.txt
+          fetch-depth: 0
+      - name: Check if there are changes to pre-commit config
+        run: git diff origin/main --exit-code -- .pre-commit-config.yml
+        continue-on-error: true
+      - uses: ComPWA/update-pre-commit@main
+        if: success()
 
   push:
     name: Push changes
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Only run if PR does not come from a fork
+    # https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow
     runs-on: ubuntu-20.04
     needs:
-      - upgrade
+      - pip-constraints
+      - pre-commit
     steps:
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.PAT }}
+        # GITHUB_TOKEN will not rerun checks after pushing to a PR branch
       - uses: actions/download-artifact@v2
-        with:
-          path: .constraints
-      - run: mv -f .constraints/artifact/* .constraints/
+      - run: |
+          [[ -f .pre-commit-config.yaml ]] && mv -f .pre-commit-config.yaml ..
+          mv -f * ../.constraints/
+        working-directory: artifact
       - run: git status -s
       - name: Commit and push changes
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/${{ github.repository }}
-          git config --global user.name "GitHub Action"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "GitHub"
+          git config --global user.email "noreply@github.com"
           git checkout -b ${GITHUB_HEAD_REF}
           if [[ $(git status -s) ]]; then
             git add -A


### PR DESCRIPTION
Simplified upgrade workflows with the following two custom, composite GitHub Actions:
- https://github.com/ComPWA/update-pip-constraints
- https://github.com/ComPWA/update-pre-commit

The `pin_requirements.py` script is also removed from the `.constraints` folder.