### PR TITLE
feat: split and simplify notebook install cells

### DIFF
--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -58,7 +58,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(__doc__)
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
     parser.add_argument(
-        "--install-cell",
+        "--add-install-cell",
         action="store_true",
         help="Add notebook cell with pip install statement.",
     )
@@ -86,13 +86,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             new_metadata=__CONFIG_CELL_METADATA,
             cell_id=0,
         )
-        if args.install_cell:
+        if args.add_install_cell:
             cell_content = __INSTALL_CELL_CONTENT.strip("\n")
             if args.extras_require:
                 extras = args.extras_require.strip()
                 cell_content += f"[{extras}]"
             if args.additional_packages:
-                packages = map(lambda s: s.strip(), args.additional_packages)
+                packages = map(
+                    lambda s: s.strip(), args.additional_packages.split(",")
+                )
                 cell_content += " " + " ".join(packages)
             _update_cell(
                 filename,

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -46,7 +46,7 @@ __CONFIG_CELL_METADATA: dict = {
 __EXTRAS_REQUIRE = "[doc]"
 __INSTALL_CELL_CONTENT = f"""
 # WARNING: advised to install a specific version, e.g. {__PACKAGE_NAME}{__EXTRAS_REQUIRE}==0.1.2
-%pip install -q {__PACKAGE_NAME}{__EXTRAS_REQUIRE} graphviz
+%pip install -q {__PACKAGE_NAME}{__EXTRAS_REQUIRE}
 """
 __INSTALL_CELL_METADATA: dict = {
     **__CONFIG_CELL_METADATA,

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -28,8 +28,6 @@ from repoma.utilities.setup_cfg import open_setup_cfg
 __SETUP_CFG = open_setup_cfg()
 __PACKAGE_NAME = __SETUP_CFG["metadata"]["name"]
 __DEFAULT_CONTENT = """
-%%capture
-%config Completer.use_jedi = False
 %config InlineBackend.figure_formats = ['svg']
 import os
 

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -57,11 +57,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(__doc__)
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
     parser.add_argument(
-        "--replace",
-        action="store_true",
-        help="Replace first cell instead of prepending a new cell.",
-    )
-    parser.add_argument(
         "--install-cell",
         action="store_true",
         help="Add notebook cell with pip install statement.",
@@ -74,7 +69,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             new_content=__CONFIG_CELL_CONTENT.strip("\n"),
             new_metadata=__CONFIG_CELL_METADATA,
             cell_id=0,
-            replace=args.replace,
         )
         if args.install_cell:
             _update_cell(
@@ -82,7 +76,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 new_content=__INSTALL_CELL_CONTENT.strip("\n"),
                 new_metadata=__INSTALL_CELL_METADATA,
                 cell_id=1,
-                replace=args.replace,
             )
     return 0
 
@@ -92,7 +85,6 @@ def _update_cell(
     new_content: str,
     new_metadata: dict,
     cell_id: int,
-    replace: bool = False,
 ) -> None:
     notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
     exiting_cell = notebook["cells"][cell_id]
@@ -108,12 +100,13 @@ def _update_cell(
             and "cell" in first_line
         ):
             return
+
     new_cell = nbformat.v4.new_code_cell(
         new_content,
         metadata=new_metadata,
     )
     del new_cell["id"]  # following nbformat_minor = 4
-    if replace:
+    if exiting_cell["cell_type"] == "code":
         notebook["cells"][cell_id] = new_cell
     else:
         notebook["cells"].insert(cell_id, new_cell)

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -1,12 +1,12 @@
 """Add install statements to first cell in a Jupyter notebook.
 
-Google Colaboratory does not install a package automatically, so this has to be
-done through a code cell. At the same time, this cell needs to be hidden from
-the documentation pages, when viewing through Jupyter Lab (Binder), and when
-viewing Jupyter slides.
+Notebook servers like Google Colaboratory and Deepnote do not install a package
+automatically, so this has to be done through a code cell. At the same time,
+this cell needs to be hidden from the documentation pages, when viewing through
+Jupyter Lab (Binder), and when viewing as Jupyter slides.
 
-Additionally, this scripts sets the IPython InlineBackend.figure_formats option
-to SVG. This is because the Sphinx configuration can't set this externally.
+This scripts sets the IPython InlineBackend.figure_formats option to SVG. This
+is because the Sphinx configuration can't set this externally.
 
 Notebooks can be ignored by making the first cell a `Markdown cell
 <https://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Working%20With%20Markdown%20Cells.html>`_
@@ -27,28 +27,14 @@ from repoma.utilities.setup_cfg import open_setup_cfg
 
 __SETUP_CFG = open_setup_cfg()
 __PACKAGE_NAME = __SETUP_CFG["metadata"]["name"]
-__DEFAULT_CONTENT = """
+
+__CONFIG_CELL_CONTENT = """
 %config InlineBackend.figure_formats = ['svg']
 import os
 
 STATIC_WEB_PAGE = {"EXECUTE_NB", "READTHEDOCS"}.intersection(os.environ)
 """
-__COLAB_CONTENT = f"""
-# Install on Google Colab
-import subprocess
-import sys
-
-from IPython import get_ipython
-
-install_packages = "google.colab" in str(get_ipython())
-if install_packages:
-    for package in ["{__PACKAGE_NAME}[doc]", "graphviz"]:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", package]
-        )
-"""
-
-__EXPECTED_CELL_METADATA = {
+__CONFIG_CELL_METADATA: dict = {
     "hideCode": True,
     "hideOutput": True,
     "hidePrompt": True,
@@ -57,14 +43,61 @@ __EXPECTED_CELL_METADATA = {
     "tags": ["remove-cell"],
 }
 
+__INSTALL_CELL_CONTENT = f"""
+%pip install -q {__PACKAGE_NAME}[doc] graphviz
+"""
+__INSTALL_CELL_METADATA: dict = {
+    **__CONFIG_CELL_METADATA,
+    "tags": ["remove-cell", "skip-execution"],
+    # https://github.com/executablebooks/jupyter-book/issues/833
+}
 
-def fix_first_cell(
-    filename: str, new_content: str, replace: bool = False
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
+    parser.add_argument(
+        "--replace",
+        action="store_true",
+        help="Replace first cell instead of prepending a new cell.",
+    )
+    parser.add_argument(
+        "--install-cell",
+        action="store_true",
+        help="Add notebook cell with pip install statement.",
+    )
+    args = parser.parse_args(argv)
+
+    for filename in args.filenames:
+        _update_cell(
+            filename,
+            new_content=__CONFIG_CELL_CONTENT.strip("\n"),
+            new_metadata=__CONFIG_CELL_METADATA,
+            cell_id=0,
+            replace=args.replace,
+        )
+        if args.install_cell:
+            _update_cell(
+                filename,
+                new_content=__INSTALL_CELL_CONTENT.strip("\n"),
+                new_metadata=__INSTALL_CELL_METADATA,
+                cell_id=1,
+                replace=args.replace,
+            )
+    return 0
+
+
+def _update_cell(
+    filename: str,
+    new_content: str,
+    new_metadata: dict,
+    cell_id: int,
+    replace: bool = False,
 ) -> None:
     notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
-    old_cell = notebook["cells"][0]
-    if old_cell["cell_type"] == "markdown":
-        old_cell_content: str = old_cell["source"]
+    exiting_cell = notebook["cells"][cell_id]
+    if exiting_cell["cell_type"] == "markdown":
+        old_cell_content: str = exiting_cell["source"]
         old_cell_content = old_cell_content.lower()
         first_line = old_cell_content.split("\n")[0]
         first_line = first_line.strip()
@@ -77,44 +110,15 @@ def fix_first_cell(
             return
     new_cell = nbformat.v4.new_code_cell(
         new_content,
-        metadata=__EXPECTED_CELL_METADATA,
+        metadata=new_metadata,
     )
     del new_cell["id"]  # following nbformat_minor = 4
     if replace:
-        notebook["cells"][0] = new_cell
+        notebook["cells"][cell_id] = new_cell
     else:
-        notebook["cells"] = [new_cell] + notebook["cells"]
+        notebook["cells"].insert(cell_id, new_cell)
     nbformat.validate(notebook)
     nbformat.write(notebook, filename)
-
-
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    parser = argparse.ArgumentParser(__doc__)
-    parser.add_argument("filenames", nargs="*", help="Filenames to check.")
-    parser.add_argument(
-        "--replace",
-        action="store_true",
-        help="Replace first cell instead of prepending a new cell.",
-    )
-    parser.add_argument(
-        "--colab",
-        action="store_true",
-        help="Add pip install statements for Google Colab.",
-    )
-    args = parser.parse_args(argv)
-
-    expected_cell_content = __DEFAULT_CONTENT.strip("\n")
-    if args.colab:
-        expected_cell_content += "\n\n"
-        expected_cell_content += __COLAB_CONTENT.strip("\n")
-    exit_code = 0
-    for filename in args.filenames:
-        fix_first_cell(
-            filename,
-            new_content=expected_cell_content,
-            replace=args.replace,
-        )
-    return exit_code
 
 
 if __name__ == "__main__":

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -43,10 +43,9 @@ __CONFIG_CELL_METADATA: dict = {
     "tags": ["remove-cell"],
 }
 
-__EXTRAS_REQUIRE = "[doc]"
 __INSTALL_CELL_CONTENT = f"""
-# WARNING: advised to install a specific version, e.g. {__PACKAGE_NAME}{__EXTRAS_REQUIRE}==0.1.2
-%pip install -q {__PACKAGE_NAME}{__EXTRAS_REQUIRE}
+# WARNING: advised to install a specific version, e.g. {__PACKAGE_NAME}==0.1.2
+%pip install -q {__PACKAGE_NAME}
 """
 __INSTALL_CELL_METADATA: dict = {
     **__CONFIG_CELL_METADATA,
@@ -90,11 +89,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         if args.install_cell:
             cell_content = __INSTALL_CELL_CONTENT.strip("\n")
             if args.extras_require:
-                cell_content = cell_content.replace(__EXTRAS_REQUIRE, "")
                 extras = args.extras_require.strip()
                 cell_content += f"[{extras}]"
             if args.additional_packages:
-                cell_content = cell_content.replace(__EXTRAS_REQUIRE, "")
                 packages = map(lambda s: s.strip(), args.additional_packages)
                 cell_content += " " + " ".join(packages)
             _update_cell(

--- a/src/repoma/fix_first_nbcell.py
+++ b/src/repoma/fix_first_nbcell.py
@@ -44,6 +44,7 @@ __CONFIG_CELL_METADATA: dict = {
 }
 
 __INSTALL_CELL_CONTENT = f"""
+# WARNING: advised to install a specific version, e.g. {__PACKAGE_NAME}[doc]==0.1.2
 %pip install -q {__PACKAGE_NAME}[doc] graphviz
 """
 __INSTALL_CELL_METADATA: dict = {

--- a/src/repoma/format_setup_cfg.py
+++ b/src/repoma/format_setup_cfg.py
@@ -49,16 +49,6 @@ def _format_setup_cfg(
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(__doc__)
     parser.add_argument("filenames", nargs="*", help="Filenames to check.")
-    parser.add_argument(
-        "--replace",
-        action="store_true",
-        help="Replace first cell instead of prepending a new cell.",
-    )
-    parser.add_argument(
-        "--colab",
-        action="store_true",
-        help="Add pip install statements for Google Colab.",
-    )
     args = parser.parse_args(argv)
     if str(CONFIG_PATH.setup_cfg) in args.filenames:
         format_setup_cfg()


### PR DESCRIPTION
Required for #43.

Other interface changes to the `fix-first-nbcell` hook:
- `--replace` argument has been removed. Whether to replace or insert is detected from the cell type.
- `--colab` argument has been renamed to `--add-install-cell`
- Added comma-separated `--extras-require` argument to specify more [optional dependencies](https://compwa-org.readthedocs.io/develop.html#optional-dependencies)
- Added comma-separated argument `--additional-packages` to install additional packages through `pip`

Tested on:
- https://github.com/ComPWA/qrules/pull/136
- https://github.com/ComPWA/ampform/pull/204
- https://github.com/ComPWA/tensorwaves/pull/400