### PR TITLE
feat: upgrade to non-beta black release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,23 +36,23 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
       - id: blacken-docs
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.97
+    rev: 0.0.99
     hooks:
       - id: check-dev-files
       - id: format-setup-cfg
 
   - repo: https://github.com/streetsidesoftware/cspell-cli
-    rev: v5.6.12
+    rev: v5.7.0
     hooks:
       - id: cspell
 
@@ -86,7 +86,7 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/ComPWA/mirrors-pyright
-    rev: v1.1.203
+    rev: v1.1.216
     hooks:
       - id: pyright
 

--- a/src/repoma/check_dev_files/black.py
+++ b/src/repoma/check_dev_files/black.py
@@ -18,7 +18,7 @@ def main() -> None:
     config = _load_config()
     executor = Executor()
     executor(_check_line_length, config)
-    executor(_check_experimental_string_processing, config)
+    executor(_check_activate_preview, config)
     executor(_check_option_ordering, config)
     executor(_check_target_versions, config)
     if executor.error_messages:
@@ -34,8 +34,8 @@ def _load_config(content: Optional[str] = None) -> dict:
     return config.get("tool", {}).get("black")
 
 
-def _check_experimental_string_processing(config: dict) -> None:
-    expected_option = "experimental-string-processing"
+def _check_activate_preview(config: dict) -> None:
+    expected_option = "preview"
     if config.get(expected_option) is not True:
         raise PrecommitError(
             dedent(

--- a/src/repoma/check_dev_files/black.py
+++ b/src/repoma/check_dev_files/black.py
@@ -9,6 +9,10 @@ import toml
 from repoma.errors import PrecommitError
 from repoma.utilities import CONFIG_PATH, natural_sorting
 from repoma.utilities.executor import Executor
+from repoma.utilities.precommit import (
+    PrecommitConfig,
+    load_round_trip_precommit_config,
+)
 from repoma.utilities.setup_cfg import get_supported_python_versions
 
 
@@ -21,6 +25,7 @@ def main() -> None:
     executor(_check_activate_preview, config)
     executor(_check_option_ordering, config)
     executor(_check_target_versions, config)
+    executor(_update_nbqa_hook)
     if executor.error_messages:
         raise PrecommitError(executor.merge_messages())
 
@@ -101,3 +106,32 @@ def _check_target_versions(config: dict) -> None:
             error_message += f"\n    '{version}',"
         error_message += "\n]"
         raise PrecommitError(error_message)
+
+
+def _update_nbqa_hook() -> None:
+    repo_url = "https://github.com/nbQA-dev/nbQA"
+    precommit_config = PrecommitConfig.load()
+    repo = precommit_config.find_repo(repo_url)
+    if repo is None:
+        return
+
+    hook_id = "nbqa-black"
+    expected_config = {
+        "id": hook_id,
+        "additional_dependencies": [
+            "black>=22.1.0",
+        ],
+    }
+    repo_index = precommit_config.get_repo_index(repo_url)
+    hook_index = repo.get_hook_index(hook_id)
+    if hook_index is None:
+        config, yaml = load_round_trip_precommit_config()
+        config["repos"][repo_index]["hooks"].append(expected_config)
+        yaml.dump(config, CONFIG_PATH.precommit)
+        raise PrecommitError(f"Added {hook_id} to pre-commit config")
+
+    if repo.hooks[hook_index].dict(skip_defaults=True) != expected_config:
+        config, yaml = load_round_trip_precommit_config()
+        config["repos"][repo_index]["hooks"][hook_index] = expected_config
+        yaml.dump(config, CONFIG_PATH.precommit)
+        raise PrecommitError(f"Updated args of {hook_id} pre-commit hook")

--- a/src/repoma/check_dev_files/editor_config.py
+++ b/src/repoma/check_dev_files/editor_config.py
@@ -17,7 +17,7 @@ __EDITORCONFIG_FILE = ".editorconfig"
 __EDITORCONFIG_URL = (
     "https://github.com/editorconfig-checker/editorconfig-checker.python"
 )
-__EDITORCONFIG_HOOK = fR"""
+__EDITORCONFIG_HOOK = Rf"""
   - repo: {__EDITORCONFIG_URL}
     rev: ""
     hooks:

--- a/src/repoma/check_dev_files/flake8.py
+++ b/src/repoma/check_dev_files/flake8.py
@@ -200,7 +200,7 @@ def _check_missing_options(
         content = cfg.get("flake8", option)
     missing_values = []
     for value in expected_values:
-        if not re.search(fr"\b{value}\b", content):
+        if not re.search(rf"\b{value}\b", content):
             missing_values.append(value)
     if missing_values:
         values = "\n".join(missing_values)

--- a/src/repoma/check_dev_files/github_workflows.py
+++ b/src/repoma/check_dev_files/github_workflows.py
@@ -68,7 +68,7 @@ def _remove_constraint_pinning(content: str) -> str:
     'pip install .[dev]'
     """
     return re.sub(
-        pattern=fr"-c {CONFIG_PATH.pip_constraints}/py3\.\d\.txt\s*",
+        pattern=rf"-c {CONFIG_PATH.pip_constraints}/py3\.\d\.txt\s*",
         repl="",
         string=content,
     )

--- a/src/repoma/utilities/precommit.py
+++ b/src/repoma/utilities/precommit.py
@@ -41,6 +41,7 @@ class Hook(BaseModel):
     id: str  # noqa: A003
     args: List[str] = []
     name: Optional[str] = None
+    additional_dependencies: List[str] = []
     files: Optional[str] = None
     exclude: Optional[str] = None
     types: Optional[List[str]] = None

--- a/tests/check_dev_files/test_black.py
+++ b/tests/check_dev_files/test_black.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 import pytest
 
 from repoma.check_dev_files.black import (
-    _check_experimental_string_processing,
+    _check_activate_preview,
     _check_line_length,
     _check_option_ordering,
     _check_target_versions,
@@ -42,16 +42,16 @@ def test_check_line_length():
         dedent(
             """
         [tool.config]
-        experimental-string-processing = false
+        preview = false
         """
         ).strip(),
     ],
 )
-def test_check_experimental_string_processing(toml_content: str):
+def test_check_activate_preview(toml_content: str):
     toml_content = """[tool.black]"""
     config = _load_config(toml_content)
     with pytest.raises(PrecommitError) as error:
-        _check_experimental_string_processing(config)
+        _check_activate_preview(config)
     assert (
         error.value.args[0]
         == dedent(
@@ -59,7 +59,7 @@ def test_check_experimental_string_processing(toml_content: str):
             An option in pyproject.toml is wrong or missing. Should be:
 
             [tool.black]
-            experimental-string-processing = true
+            preview = true
             """
         ).strip()
     )
@@ -107,14 +107,14 @@ def test_load_config_from_string():
     toml_content = dedent(
         R"""
         [tool.black]
-        experimental-string-processing = true
+        preview = true
         include = '\.pyi?$'
         line-length = 79
         """
     ).strip()
     config = _load_config(toml_content)
     assert config == {
-        "experimental-string-processing": True,
+        "preview": True,
         "include": R"\.pyi?$",
         "line-length": 79,
     }
@@ -124,8 +124,8 @@ def test_check_option_ordering():
     toml_content = dedent(
         R"""
         [tool.black]
+        preview = true
         line-length = 79
-        experimental-string-processing = true
         """
     ).strip()
     config = _load_config(toml_content)
@@ -138,8 +138,8 @@ def test_check_option_ordering():
             Options in pyproject.toml should be alphabetically sorted:
 
             [tool.black]
-            experimental-string-processing = ...
             line-length = ...
+            preview = ...
             """
         ).strip()
     )

--- a/tests/utilities/test_cfg.py
+++ b/tests/utilities/test_cfg.py
@@ -97,7 +97,7 @@ def test_get_repo_url():
 def test_open_config_exception():
     path = "non-existent.cfg"
     with pytest.raises(
-        PrecommitError, match=fr'^Config file "{path}" does not exist$'
+        PrecommitError, match=rf'^Config file "{path}" does not exist$'
     ):
         open_config(path)
 


### PR DESCRIPTION
Black made it's first non-beta release: [v22.1.0](https://github.com/psf/black/releases/tag/22.1.0). Repo-maintenance will:

- enforce [`preview = true`](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style) instead of experimental string processing
- enforce this first release on `nbqa-black`