### PR TITLE
feat: insert autolink-concat directive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: blacken-docs
 
   - repo: https://github.com/ComPWA/repo-maintenance
-    rev: 0.0.99
+    rev: 0.0.100
     hooks:
       - id: check-dev-files
       - id: format-setup-cfg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ exclude = '''
     | dist
 )/
 '''
-experimental-string-processing = true
 include = '\.pyi?$'
 line-length = 79
+preview = true
 target-version = [
     'py36',
     'py37',


### PR DESCRIPTION
The `fix-first-nbcell` hook now adds an [`autolink-concat`](https://sphinx-codeautolink.readthedocs.io/en/latest/reference.html#directive-autolink-concat) directive to each notebook. This behaviour can be deactivated globally with:

```yaml

  - repo: https://github.com/ComPWA/repo-maintenance
    rev: ...
    hooks:
      - id: fix-first-nbcell
        args:
          - --no-autolink-concat
```

or per notebook by writing the following comment in any markdown cell:

```markdown
<!-- no autolink-concat -->
```