### PR TITLE
fix: run requirements cron job on even weeks only

### DIFF
--- a/src/repoma/.github/workflows/requirements-cron.yml
+++ b/src/repoma/.github/workflows/requirements-cron.yml
@@ -6,8 +6,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  is-even-week:
+    name: Check week number is even
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Determine if week number is even
+        run: |
+          WEEK_NUMBER=$(date +%U)
+          IS_EVEN_WEEK="$(($WEEK_NUMBER % 2 == 0))"
+          echo "This is week $WEEK_NUMBER. It even week: $IS_EVEN_WEEK"
+          echo ::set-output name=is-even-week::"$IS_EVEN_WEEK"
+        id: is-even-week
+    outputs:
+      is-even-week: ${{ steps.is-even-week.outputs.is-even-week }}
+
   pip-constraints:
     name: Update pip constraints files
+    needs: is-even-week
+    if: needs.is-even-week.outputs.is-even-week != 0
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -21,6 +37,8 @@ jobs:
 
   pre-commit:
     name: pre-commit autoupdate
+    needs: is-even-week
+    if: needs.is-even-week.outputs.is-even-week != 0
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
bb3a47f introduced a bug: it lets the requirements upgrade cron job on every other week, _but starting on the first day of each month_. The result is that the weekday on which the cron job runs switches each month. For certain months, this can also result in redundant pull requests like https://github.com/ComPWA/qrules/pull/148, https://github.com/ComPWA/ampform/pull/223, and https://github.com/ComPWA/tensorwaves/pull/408. (They have been modified to include the fix by this repo-maintenance PR.)

- See an example of a skipped job for an odd week here:
  https://github.com/ComPWA/ampform/actions/runs/1778324274
- Similarly, here's a test run (cancelled) in case the week number is marked as even:
  https://github.com/ComPWA/ampform/actions/runs/1778340043