### PR TITLE
refactor: rename fix-first-nbcell to set-nb-cells

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,20 +5,6 @@
   always_run: true
   pass_filenames: false
 
-- id: fix-first-nbcell
-  name: Check and fix first cells in notebooks
-  description: >
-    Add or replace the first cell in a Jupyter notebook by adding install
-    statements and IPython configurations.
-  entry: fix-first-nbcell
-  exclude: >
-    (?x)^(
-      docs/adr/.*
-    )$
-  language: python
-  types:
-    - jupyter
-
 - id: fix-nbformat-version
   name: Set nbformat minor version to 4 and remove cell IDs
   entry: fix-nbformat-version
@@ -38,6 +24,19 @@
     Specify which packages to install specifically in order to run this
     notebook.
   entry: pin-nb-requirements
+  language: python
+  types:
+    - jupyter
+
+- id: set-nb-cells
+  name: Add or update default cells in a Jupyter notebook
+  description: >
+    Add or replace certain default cells in a Jupyter notebook.
+  entry: set-nb-cells
+  exclude: >
+    (?x)^(
+      docs/adr/.*
+    )$
   language: python
   types:
     - jupyter

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ repos:
     rev: ""
     hooks:
       - id: check-dev-files
-      - id: fix-first-nbcell
       - id: fix-nbformat-version
       - id: format-setup-cfg
       - id: pin-nb-requirements
+      - id: set-nb-cells
 ```
 
 then run `pre-commit autoupdate`. This example lists all available hooks

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,10 +83,10 @@ dev =
 [options.entry_points]
 console_scripts =
     check-dev-files = repoma.check_dev_files:main
-    fix-first-nbcell = repoma.fix_first_nbcell:main
     fix-nbformat-version = repoma.fix_nbformat_version:main
     format-setup-cfg = repoma.format_setup_cfg:main
     pin-nb-requirements = repoma.pin_nb_requirements:main
+    set-nb-cells = repoma.set_nb_cells:main
 
 [options.packages.find]
 where = src

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -120,7 +120,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             if "ipython" in args.additional_packages.lower():
                 config_cell_content = config_cell_content.replace(
                     "import os",
-                    "import os\n\nfrom IPython.display import display",
+                    "import os\n\nfrom IPython.display import display  # noqa:"
+                    " F401",
                 )
             _update_cell(
                 filename,

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -184,7 +184,10 @@ def _insert_autolink_concat(
             return
         new_cell = nbformat.v4.new_markdown_cell(expected_cell_content)
         del new_cell["id"]  # following nbformat_minor = 4
-        notebook["cells"].insert(cell_id, new_cell)
+        if cell_content.startswith("```{autolink-concat}"):
+            notebook["cells"][cell_id] = new_cell
+        else:
+            notebook["cells"].insert(cell_id, new_cell)
         nbformat.validate(notebook)
         nbformat.write(notebook, filename)
         return

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -34,8 +34,6 @@ __CONFIG_CELL_CONTENT = """
 %config InlineBackend.figure_formats = ['svg']
 import os
 
-from IPython.display import display
-
 STATIC_WEB_PAGE = {"EXECUTE_NB", "READTHEDOCS"}.intersection(os.environ)
 """
 __CONFIG_CELL_METADATA: dict = {
@@ -91,6 +89,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ),
         type=str,
     )
+    parser.add_argument(
+        "--no-config-cell",
+        action="store_true",
+        help="Do not add configuration cell.",
+    )
     args = parser.parse_args(argv)
 
     for filename in args.filenames:
@@ -112,12 +115,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 cell_id=cell_id,
             )
             cell_id += 1
-        _update_cell(
-            filename,
-            new_content=__CONFIG_CELL_CONTENT.strip("\n"),
-            new_metadata=__CONFIG_CELL_METADATA,
-            cell_id=cell_id,
-        )
+        if not args.no_config_cell:
+            config_cell_content = __CONFIG_CELL_CONTENT
+            if "ipython" in args.additional_packages.lower():
+                config_cell_content = config_cell_content.replace(
+                    "import os",
+                    "import os\n\nfrom IPython.display import display",
+                )
+            _update_cell(
+                filename,
+                new_content=config_cell_content.strip("\n"),
+                new_metadata=__CONFIG_CELL_METADATA,
+                cell_id=cell_id,
+            )
         _insert_autolink_concat(filename)
     return 0
 

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -1,4 +1,4 @@
-"""Add install statements to first cell in a Jupyter notebook.
+"""Add or update standard cells in a Jupyter notebook.
 
 Notebook servers like Google Colaboratory and Deepnote do not install a package
 automatically, so this has to be done through a code cell. At the same time,
@@ -10,11 +10,12 @@ is because the Sphinx configuration can't set this externally.
 
 Notebooks can be ignored by making the first cell a `Markdown cell
 <https://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Working%20With%20Markdown%20Cells.html>`_
-and starting its content with:
+and writing the following `Markdown comment
+<https://www.markdownguide.org/hacks/#comments>`_:
 
 .. code-block:: markdown
 
-    <!-- ignore first cell -->
+    <!-- no-set-nb-cells -->
 """
 
 import argparse
@@ -166,7 +167,7 @@ def _insert_autolink_concat(filename: str) -> None:
 
 
 def _skip_notebook(
-    filename: str, ignore_statement: str = "<!-- ignore first cell -->"
+    filename: str, ignore_statement: str = "<!-- no-set-nb-cells -->"
 ) -> bool:
     notebook = nbformat.read(filename, as_version=nbformat.NO_CONVERT)
     for cell in notebook["cells"]:

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -92,12 +92,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     for filename in args.filenames:
-        _update_cell(
-            filename,
-            new_content=__CONFIG_CELL_CONTENT.strip("\n"),
-            new_metadata=__CONFIG_CELL_METADATA,
-            cell_id=0,
-        )
+        cell_id = 0
         if args.add_install_cell:
             cell_content = __INSTALL_CELL_CONTENT.strip("\n")
             if args.extras_require:
@@ -112,8 +107,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 filename,
                 new_content=cell_content,
                 new_metadata=__INSTALL_CELL_METADATA,
-                cell_id=1,
+                cell_id=cell_id,
             )
+            cell_id += 1
+        _update_cell(
+            filename,
+            new_content=__CONFIG_CELL_CONTENT.strip("\n"),
+            new_metadata=__CONFIG_CELL_METADATA,
+            cell_id=cell_id,
+        )
         _insert_autolink_concat(filename)
     return 0
 

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -116,19 +116,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             )
             cell_id += 1
         if not args.no_config_cell:
-            config_cell_content = __CONFIG_CELL_CONTENT
-            if "ipython" in args.additional_packages.lower():
-                config_cell_content = config_cell_content.replace(
-                    "import os",
-                    "import os\n\nfrom IPython.display import display  # noqa:"
-                    " F401",
-                )
             _update_cell(
                 filename,
-                new_content=config_cell_content.strip("\n"),
+                new_content=__CONFIG_CELL_CONTENT.strip("\n"),
                 new_metadata=__CONFIG_CELL_METADATA,
                 cell_id=cell_id,
             )
+            cell_id += 1
+            if "ipython" in args.additional_packages.lower():
+                _update_cell(
+                    filename,
+                    new_content=(
+                        "from IPython.display import display  # noqa: F401"
+                    ),
+                    new_metadata={
+                        **__CONFIG_CELL_METADATA,
+                        "tags": ["hide-cell"],
+                    },
+                    cell_id=cell_id,
+                )
+                cell_id += 1
         _insert_autolink_concat(filename)
     return 0
 

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -34,6 +34,8 @@ __CONFIG_CELL_CONTENT = """
 %config InlineBackend.figure_formats = ['svg']
 import os
 
+from IPython.display import display
+
 STATIC_WEB_PAGE = {"EXECUTE_NB", "READTHEDOCS"}.intersection(os.environ)
 """
 __CONFIG_CELL_METADATA: dict = {

--- a/src/repoma/set_nb_cells.py
+++ b/src/repoma/set_nb_cells.py
@@ -21,7 +21,7 @@ and writing the following `Markdown comment
 import argparse
 import sys
 from textwrap import dedent
-from typing import List, Optional, Sequence
+from typing import Optional, Sequence
 
 import nbformat
 
@@ -129,10 +129,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 new_metadata=__CONFIG_CELL_METADATA,
                 cell_id=cell_id,
             )
-        imports = []
-        if "ipython" in args.additional_packages.lower():
-            imports.append("from IPython.display import display")
-        _insert_autolink_concat(filename, imports)
+        _insert_autolink_concat(filename)
     return 0
 
 
@@ -159,9 +156,7 @@ def _update_cell(
     nbformat.write(notebook, filename)
 
 
-def _insert_autolink_concat(
-    filename: str, imports: Optional[List[str]] = None
-) -> None:
+def _insert_autolink_concat(filename: str) -> None:
     if _skip_notebook(
         filename, ignore_statement="<!-- no autolink-concat -->"
     ):
@@ -171,11 +166,7 @@ def _insert_autolink_concat(
     ```{autolink-concat}
     ```
     """
-    expected_cell_content = dedent(expected_cell_content)
-    if imports is not None:
-        preface = "```{autolink-preface}\n" + "\n".join(imports) + "\n```"
-        expected_cell_content += preface
-    expected_cell_content = expected_cell_content.strip()
+    expected_cell_content = dedent(expected_cell_content).strip()
     for cell_id, cell in enumerate(notebook["cells"]):
         if cell["cell_type"] != "markdown":
             continue
@@ -184,10 +175,7 @@ def _insert_autolink_concat(
             return
         new_cell = nbformat.v4.new_markdown_cell(expected_cell_content)
         del new_cell["id"]  # following nbformat_minor = 4
-        if cell_content.startswith("```{autolink-concat}"):
-            notebook["cells"][cell_id] = new_cell
-        else:
-            notebook["cells"].insert(cell_id, new_cell)
+        notebook["cells"].insert(cell_id, new_cell)
         nbformat.validate(notebook)
         nbformat.write(notebook, filename)
         return


### PR DESCRIPTION
_Tested this PR https://github.com/ComPWA/ampform/pull/226._

### Interface changes
Sub-hook `--fix-first-nbcell` has been renamed to `--set-nb-cell`. Use the following example config instead:
```yaml
  - repo: https://github.com/ComPWA/repo-maintenance
    rev: ...
    hooks:
      - id: set-nb-cells
        args:
          - --add-install-cell
          - --additional-packages=IPython
          - --extras-require=doc,viz
```

Notebooks can be ignored by adding a Markdown cell with comment `<!-- no-set-nb-cells -->`.

### New features
- Added an import statement `from IPython.display import display`. This is to:
  - help syntax highlighting when viewing the notebook in VS Code.
  - render `display` statements as links in the documentation (see https://github.com/ComPWA/compwa-org/issues/106). See example of a [`display()`](https://ipython.readthedocs.io/en/8.0.1/api/generated/IPython.display.html#IPython.display.display) link [here](https://ampform--226.org.readthedocs.build/en/226/usage/modify.html#parameter-substitution).
- Config cell and install cell have been switched: install cell comes _before_ the config cell